### PR TITLE
纠正表格“隐藏全部列”和“显示全部列”按钮只操作最后一列问题

### DIFF
--- a/src/components/dashboard/clients/clients-table.tsx
+++ b/src/components/dashboard/clients/clients-table.tsx
@@ -399,20 +399,24 @@ function TableClients(): React.JSX.Element {
     },
     onSortingChange: setSorting,
     onColumnVisibilityChange: (updaterOrValue) => {
-      const newVisibility =
-        typeof updaterOrValue === 'function'
-          ? updaterOrValue(columnVisibility)
-          : updaterOrValue;
-      setColumnVisibility(newVisibility);
-      localStorage.setItem(COLUMN_VISIBILITY_KEY, JSON.stringify(newVisibility));
+        setColumnVisibility((prev) => {
+          const newVisibility =
+              typeof updaterOrValue === 'function'
+                  ? updaterOrValue(prev)
+                  : updaterOrValue;
+          localStorage.setItem(COLUMN_VISIBILITY_KEY, JSON.stringify(newVisibility));
+          return newVisibility;
+        });
     },
     onColumnSizingChange: (updaterOrValue) => {
-      const newSizing =
-        typeof updaterOrValue === 'function'
-          ? updaterOrValue(columnSizing)
-          : updaterOrValue;
-      setColumnSizing(newSizing);
-      localStorage.setItem(COLUMN_SIZING_KEY, JSON.stringify(newSizing));
+      setColumnSizing((prev) => {
+          const newSizing =
+            typeof updaterOrValue === 'function'
+              ? updaterOrValue(prev)
+              : updaterOrValue;
+          localStorage.setItem(COLUMN_SIZING_KEY, JSON.stringify(newSizing));
+          return newSizing;
+        });
     },
     renderTopToolbarCustomActions: () => (
       <Tooltip arrow title={t("Refresh Data")}>

--- a/src/components/dashboard/query-log/query-log-table.tsx
+++ b/src/components/dashboard/query-log/query-log-table.tsx
@@ -534,20 +534,24 @@ function TableQueryLogs(): React.JSX.Element {
     },
     onSortingChange: setSorting,
     onColumnVisibilityChange: (updaterOrValue) => {
-      const newVisibility =
-        typeof updaterOrValue === 'function'
-          ? updaterOrValue(columnVisibility)
-          : updaterOrValue;
-      setColumnVisibility(newVisibility);
-      localStorage.setItem(COLUMN_VISIBILITY_KEY, JSON.stringify(newVisibility));
+        setColumnVisibility((prev) => {
+          const newVisibility =
+              typeof updaterOrValue === 'function'
+                  ? updaterOrValue(prev)
+                  : updaterOrValue;
+          localStorage.setItem(COLUMN_VISIBILITY_KEY, JSON.stringify(newVisibility));
+          return newVisibility;
+        });
     },
     onColumnSizingChange: (updaterOrValue) => {
-      const newSizing =
-        typeof updaterOrValue === 'function'
-          ? updaterOrValue(columnSizing)
-          : updaterOrValue;
-      setColumnSizing(newSizing);
-      localStorage.setItem(COLUMN_SIZING_KEY, JSON.stringify(newSizing));
+      setColumnSizing((prev) => {
+          const newSizing =
+            typeof updaterOrValue === 'function'
+              ? updaterOrValue(prev)
+              : updaterOrValue;
+          localStorage.setItem(COLUMN_SIZING_KEY, JSON.stringify(newSizing));
+          return newSizing;
+        });
     },
     renderTopToolbarCustomActions: () => (
       <Tooltip arrow title={t("Refresh Data")}>

--- a/src/components/dashboard/upstream-servers/upstream-servers-table.tsx
+++ b/src/components/dashboard/upstream-servers/upstream-servers-table.tsx
@@ -219,20 +219,24 @@ function TableUpstreamServers(): React.JSX.Element {
       </Tooltip>
     ),
     onColumnVisibilityChange: (updaterOrValue) => {
-      const newVisibility =
-        typeof updaterOrValue === 'function'
-          ? updaterOrValue(columnVisibility)
-          : updaterOrValue;
-      setColumnVisibility(newVisibility);
-      localStorage.setItem(COLUMN_VISIBILITY_KEY, JSON.stringify(newVisibility));
+        setColumnVisibility((prev) => {
+          const newVisibility =
+              typeof updaterOrValue === 'function'
+                  ? updaterOrValue(prev)
+                  : updaterOrValue;
+          localStorage.setItem(COLUMN_VISIBILITY_KEY, JSON.stringify(newVisibility));
+          return newVisibility;
+        });
     },
     onColumnSizingChange: (updaterOrValue) => {
-      const newSizing =
-        typeof updaterOrValue === 'function'
-          ? updaterOrValue(columnSizing)
-          : updaterOrValue;
-      setColumnSizing(newSizing);
-      localStorage.setItem(COLUMN_SIZING_KEY, JSON.stringify(newSizing));
+      setColumnSizing((prev) => {
+          const newSizing =
+            typeof updaterOrValue === 'function'
+              ? updaterOrValue(prev)
+              : updaterOrValue;
+          localStorage.setItem(COLUMN_SIZING_KEY, JSON.stringify(newSizing));
+          return newSizing;
+        });
     },
     initialState: {
       showGlobalFilter: true,


### PR DESCRIPTION
纠正表格“隐藏全部列”和“显示全部列”按钮只操作最后一列问题，以及纠正显示/隐藏列和列宽的本地存储