### PR TITLE
disable ClickToCopy permanently

### DIFF
--- a/src/components/dashboard/clients/clients-table.tsx
+++ b/src/components/dashboard/clients/clients-table.tsx
@@ -360,7 +360,7 @@ function TableClients(): React.JSX.Element {
     enableColumnOrdering: true,
     enableRowActions: true,
     enableCellActions: true,
-    enableClickToCopy: window.isSecureContext,
+    enableClickToCopy: false,
     enableGlobalFilter: false,
     columnFilterDisplayMode: 'popover',
     enableColumnFilterModes: true,

--- a/src/components/dashboard/query-log/query-log-table.tsx
+++ b/src/components/dashboard/query-log/query-log-table.tsx
@@ -547,7 +547,7 @@ function TableQueryLogs(): React.JSX.Element {
     enableColumnOrdering: true,
     enableRowActions: true,
     enableCellActions: true,
-    enableClickToCopy: window.isSecureContext,
+    enableClickToCopy: false,
     enableGlobalFilter: false,
     columnFilterDisplayMode: 'popover',
     enableColumnFilterModes: true,

--- a/src/components/dashboard/upstream-servers/upstream-servers-table.tsx
+++ b/src/components/dashboard/upstream-servers/upstream-servers-table.tsx
@@ -197,7 +197,7 @@ function TableUpstreamServers(): React.JSX.Element {
     enableColumnActions: false,
     enableColumnFilters: false,
     enableSorting: true,
-    enableClickToCopy: window.isSecureContext,
+    enableClickToCopy: false,
     enableGlobalFilter: true,
     enableColumnFilterModes: false,
     enableColumnPinning: true,


### PR DESCRIPTION
在启用 https 后 ClickToCopy 与 Tooltip （ https://github.com/pymumu/smartdns-webui/pull/55 ）功能冲突，应永久关闭 ClickToCopy